### PR TITLE
Add DuplicateResourceError class

### DIFF
--- a/server/src/middlewares/errorHandler.js
+++ b/server/src/middlewares/errorHandler.js
@@ -1,12 +1,15 @@
 import { z } from 'zod';
 import mongoose from 'mongoose';
 import { logger } from '../config/index.js';
-
-
+import { DuplicateResourceError } from '../utils/customErrors.js';
 
 const errorHandler = (err, req, res, next) => {
   if (err instanceof z.ZodError) {
     return res.status(400).send(err.errors);
+  }
+
+  if (err instanceof DuplicateResourceError) {
+    return res.status(409).send(err.message);
   }
 
   if (

--- a/server/src/services/signup.js
+++ b/server/src/services/signup.js
@@ -1,6 +1,13 @@
 import { User } from '../models/index.js';
+import { DuplicateResourceError } from '../utils/customErrors.js';
 
 export const signup = async ({ name, email, mobile, password }) => {
+  const userAlredyExists = await User.findOne({ email });
+  if (userAlredyExists) {
+    throw new DuplicateResourceError(
+      `User with email ${email} is already registered`
+    );
+  }
   const user = new User({
     name,
     email,

--- a/server/src/utils/customErrors.js
+++ b/server/src/utils/customErrors.js
@@ -1,0 +1,8 @@
+export class DuplicateResourceError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = 409;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}


### PR DESCRIPTION
## Related Issue [70](https://github.com/orgs/bongodev/projects/3/views/1?pane=issue&itemId=103087353&issue=bongodev%7Cappointment-booking%7C70)

<!-- Give the link of the related issue -->

### Description
Created a custom **DuplicateResourceError** class that extends the built-in Error class. This error is specifically designed to handle situations where a resource already exists.

<!-- Give a brief description about the task -->

#### Usage
````
if (resourceExists) {
  throw new DuplicateResourceError('Resource with this identifier already exists.');
}
```

### QA Steps

- [ ] <!-- step 1 -->
