### PR TITLE
[Nazma] Add dates and month in the slots table 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@mui/x-date-pickers": "^7.26.0",
     "@tanstack/react-query": "^5.70.0",
     "axios": "^1.8.3",
+    "dayjs": "^1.11.13",
     "moment": "^2.30.1",
     "path": "^0.12.7",
     "react": "^19.0.0",

--- a/client/src/components/SlotTable.tsx
+++ b/client/src/components/SlotTable.tsx
@@ -32,15 +32,35 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
 
 const getWeekDates = () => {
   const today = dayjs();
-  const startOfWeek = today.startOf('week'); 
+  const startOfWeek = today.startOf('week');
   return Array.from({ length: 7 }, (_, i) => startOfWeek.add(i, 'day'));
 };
 
 export default function SlotTable({}: SlotTableProps) {
   const weekDates = getWeekDates();
 
+  const isSameMonth = weekDates[0].month() === weekDates[6].month();
+
+  const weekLabel = isSameMonth
+    ? weekDates[0].format('MMMM YYYY')
+    : `${weekDates[0].format('MMM D')} – ${weekDates[6].format('MMM D, YYYY')}`;
+
   return (
     <Box sx={{ mt: 3 }}>
+      <Box>
+        <div
+          style={{
+            fontWeight: 'bold',
+            fontSize: 18,
+            backgroundColor: 'white',
+            color: 'primary.main',
+            textAlign: 'center',
+            margin: 5,
+          }}
+        >
+          {weekLabel}
+        </div>
+      </Box>
       <TableContainer sx={{ minWidth: 700, maxHeight: 550 }} component={Paper}>
         <Table stickyHeader aria-label="sticky table">
           <TableHead>
@@ -56,7 +76,7 @@ export default function SlotTable({}: SlotTableProps) {
                     key={index}
                     align="center"
                     sx={{
-                      bgcolor: isToday ? 'gray' : 'primary.main', 
+                      bgcolor: isToday ? 'gray' : 'primary.main',
                       color: 'white',
                       border: '1px solid rgba(224, 224, 224, 1)',
                     }}

--- a/client/src/components/SlotTable.tsx
+++ b/client/src/components/SlotTable.tsx
@@ -6,8 +6,9 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
-import { weekDays, timeSlots, daySlots } from '@/data';
+import { timeSlots, daySlots } from '@/data';
 import { Box, Button } from '@mui/material';
+import dayjs from 'dayjs';
 
 type SlotTableProps = {};
 
@@ -29,19 +30,46 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
   },
 }));
 
+const getWeekDates = () => {
+  const today = dayjs();
+  const startOfWeek = today.startOf('week'); 
+  return Array.from({ length: 7 }, (_, i) => startOfWeek.add(i, 'day'));
+};
+
 export default function SlotTable({}: SlotTableProps) {
+  const weekDates = getWeekDates();
+
   return (
     <Box sx={{ mt: 3 }}>
-      <TableContainer  sx={{ minWidth: 700, maxHeight:550 }} component={Paper}>
+      <TableContainer sx={{ minWidth: 700, maxHeight: 550 }} component={Paper}>
         <Table stickyHeader aria-label="sticky table">
           <TableHead>
             <TableRow>
               <StyledTableCell component="th" scope="row" sx={{ width: 180 }}>
                 Time
               </StyledTableCell>
-              {weekDays.map((day) => (
-                <StyledTableCell>{day}</StyledTableCell>
-              ))}
+              {weekDates.map((date, index) => {
+                const isToday = date.isSame(dayjs(), 'day');
+
+                return (
+                  <TableCell
+                    key={index}
+                    align="center"
+                    sx={{
+                      bgcolor: isToday ? 'gray' : 'primary.main', 
+                      color: 'white',
+                      border: '1px solid rgba(224, 224, 224, 1)',
+                    }}
+                  >
+                    <div style={{ fontWeight: 'bold', fontSize: 15 }}>
+                      {date.format('DD')}
+                    </div>
+                    <div style={{ fontSize: 8 }}>
+                      {date.format('ddd').toUpperCase()}
+                    </div>
+                  </TableCell>
+                );
+              })}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -84,7 +112,7 @@ export default function SlotTable({}: SlotTableProps) {
           </TableBody>
         </Table>
       </TableContainer>
-      <Box sx={{ display: 'flex', flexDirection:'row-reverse', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'row-reverse', gap: 2 }}>
         <Button variant="contained" color="primary">
           Save Changes
         </Button>
@@ -95,3 +123,4 @@ export default function SlotTable({}: SlotTableProps) {
     </Box>
   );
 }
+

--- a/client/src/data/index.ts
+++ b/client/src/data/index.ts
@@ -163,8 +163,6 @@ export const mockSlots: Slot[] = [
   },
 ];
 
-export const weekDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-
 export const timeSlots = [
   '8 AM - 9 AM',
   '9 AM - 10 AM',
@@ -201,3 +199,4 @@ export const daySlots = [
   'friSlot',
   'satSlot',
 ];
+

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1253,6 +1253,11 @@ csstype@^3.0.2, csstype@^3.1.3:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"


### PR DESCRIPTION
## Related Issue URL: #98 

<!-- Give the link of the related issue -->

### Description

- Add dayjs library for dates and days
- Fetch current weekdays
- Highlight the date and day of current day
- Add month and year on top of the table

<!-- Give a brief description about the task -->

### Screenshots 
![image](https://github.com/user-attachments/assets/8d4e6c95-243d-44ff-9907-efc1e35bd5d2)


### QA Steps

- [ ] Install dayjs library - `yarn add dayjs`
- [ ] Go to slots page following the url - `{{baseURL}}/admin/slots`
